### PR TITLE
Fix syntax error

### DIFF
--- a/sch/isdoc-6.0.2.sch
+++ b/sch/isdoc-6.0.2.sch
@@ -235,7 +235,7 @@
           faktury musí být stejné. Pokud atribut pro jednotku v rozpisu šarží/sériových čísel není
           uveden, tak se předpokládá, že je množství uvedeno ve stejné jednotce jako množství na
           řádce faktury. </sch:assert>
-            <sch:assert test="if (isdoc:InvoicedQuantity/@unitCode) then                                 every $q in isdoc:Item/isdoc:StoreBatches/isdoc:StoreBatch/isdoc:Quantity) satisfies $q/@unitCode = isdoc:InvoicedQuantity/@unitCode                               else true()">Jednotka v rozpisu všech šarží/sériových čísel (element StoreBatches) musí
+            <sch:assert test="if (isdoc:InvoicedQuantity/@unitCode) then every $q in isdoc:Item/isdoc:StoreBatches/isdoc:StoreBatch/isdoc:Quantity satisfies $q/@unitCode = isdoc:InvoicedQuantity/@unitCode else true()">Jednotka v rozpisu všech šarží/sériových čísel (element StoreBatches) musí
           být stejná jako jednotka pro množství na řádce faktury. Jednotky u šarží jedné řádky
           faktury musí být stejné. Pokud atribut pro jednotku v rozpisu šarží/sériových čísel není
           uveden, tak se předpokládá, že je množství uvedeno ve stejné jednotce jako množství na


### PR DESCRIPTION
Pri pokusu validovat ISDOC pravidla selze priprava validacnich schemat:

docker run --rm -i -u $(id -u) -v $(pwd):/src klakegg/saxon xslt -s:isdoc-6.0.2.sch -xsl:iso-schematron-xslt2/iso_dsdl_include.xsl -o:temp1.sch

Bad assert: XPath syntax error. Extra close parenthesis. Suggestion: remove ')'.